### PR TITLE
Update default GitHub star count

### DIFF
--- a/src/theme/GitHubStarNavbarItem/index.js
+++ b/src/theme/GitHubStarNavbarItem/index.js
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 
-const DEFAULT_STAR_COUNT = 1171; // latest count used to avoid showing a zero-star count before the first successful fetch
+const DEFAULT_STAR_COUNT = 1172; // latest count used to avoid showing a zero-star count before the first successful fetch
 const STAR_COUNT_CACHE_TTL = 1000 * 60 * 30;
 
 function formatFullStarCount(count) {

--- a/src/theme/GitHubStarNavbarItem/index.js
+++ b/src/theme/GitHubStarNavbarItem/index.js
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 
+// Keep the fallback close to the current real star count so first render stays credible before the live fetch completes.
 const DEFAULT_STAR_COUNT = 1172; // latest count used to avoid showing a zero-star count before the first successful fetch
 const STAR_COUNT_CACHE_TTL = 1000 * 60 * 30;
 


### PR DESCRIPTION
## Summary
- bump the default star count fallback from 1171 to 1172

## Testing
- not run (constant change only)
