### PR TITLE
docs: CLI install scripts and v2 install page

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,0 +1,64 @@
+---
+sidebar_position: 3
+title: CLI
+description: Install and use the Durable Workflow command-line interface.
+---
+
+import CliInstall from '@site/src/components/CliInstall';
+
+# Durable Workflow CLI
+
+The `durable-workflow` CLI talks to a [Durable Workflow Server](https://github.com/durable-workflow/server) from your shell — start and inspect workflows, send signals, manage schedules and namespaces, run repair sweeps, and stream event history.
+
+## Install
+
+<CliInstall />
+
+### Other options
+
+- **PHAR** (requires PHP ≥ 8.4). Grab `durable-workflow.phar` from the [releases page](https://github.com/durable-workflow/cli/releases) and run it with `php durable-workflow.phar`.
+- **Composer**:
+  ```bash
+  composer global require durable-workflow/cli
+  ```
+
+### Verify
+
+```bash
+durable-workflow --version
+```
+
+## Configure
+
+Point the CLI at your server:
+
+```bash
+export DURABLE_WORKFLOW_SERVER_URL=http://localhost:8080
+export DURABLE_WORKFLOW_AUTH_TOKEN=your-token
+export DURABLE_WORKFLOW_NAMESPACE=default
+```
+
+Or pass them as options per-command:
+
+```bash
+durable-workflow --server=http://localhost:8080 --token=... workflow:list
+```
+
+## Common commands
+
+```bash
+durable-workflow server:health
+durable-workflow server:info
+
+durable-workflow workflow:start --type=order.process --input='{"order_id":123}'
+durable-workflow workflow:list --status=running
+durable-workflow workflow:describe order-123
+durable-workflow workflow:signal order-123 payment-received --input='{"amount":99.99}'
+durable-workflow workflow:history order-123 01HXYZ --follow
+
+durable-workflow schedule:create --workflow-type=reports.daily --cron="0 9 * * *"
+durable-workflow namespace:list
+durable-workflow task-queue:describe default
+```
+
+See the [CLI repository README](https://github.com/durable-workflow/cli#commands) for the full command reference.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -8,7 +8,7 @@ import CliInstall from '@site/src/components/CliInstall';
 
 # Durable Workflow CLI
 
-The `durable-workflow` CLI talks to a [Durable Workflow Server](https://github.com/durable-workflow/server) from your shell — start and inspect workflows, send signals, manage schedules and namespaces, run repair sweeps, and stream event history.
+The `dw` CLI talks to a [Durable Workflow Server](https://github.com/durable-workflow/server) from your shell — start and inspect workflows, send signals, manage schedules and namespaces, run repair sweeps, and stream event history.
 
 ## Install
 
@@ -16,7 +16,7 @@ The `durable-workflow` CLI talks to a [Durable Workflow Server](https://github.c
 
 ### Other options
 
-- **PHAR** (requires PHP ≥ 8.4). Grab `durable-workflow.phar` from the [releases page](https://github.com/durable-workflow/cli/releases) and run it with `php durable-workflow.phar`.
+- **PHAR** (requires PHP ≥ 8.4). Grab `dw.phar` from the [releases page](https://github.com/durable-workflow/cli/releases) and run it with `php dw.phar`.
 - **Composer**:
   ```bash
   composer global require durable-workflow/cli
@@ -25,7 +25,7 @@ The `durable-workflow` CLI talks to a [Durable Workflow Server](https://github.c
 ### Verify
 
 ```bash
-durable-workflow --version
+dw --version
 ```
 
 ## Configure
@@ -41,24 +41,24 @@ export DURABLE_WORKFLOW_NAMESPACE=default
 Or pass them as options per-command:
 
 ```bash
-durable-workflow --server=http://localhost:8080 --token=... workflow:list
+dw --server=http://localhost:8080 --token=... workflow:list
 ```
 
 ## Common commands
 
 ```bash
-durable-workflow server:health
-durable-workflow server:info
+dw server:health
+dw server:info
 
-durable-workflow workflow:start --type=order.process --input='{"order_id":123}'
-durable-workflow workflow:list --status=running
-durable-workflow workflow:describe order-123
-durable-workflow workflow:signal order-123 payment-received --input='{"amount":99.99}'
-durable-workflow workflow:history order-123 01HXYZ --follow
+dw workflow:start --type=order.process --input='{"order_id":123}'
+dw workflow:list --status=running
+dw workflow:describe order-123
+dw workflow:signal order-123 payment-received --input='{"amount":99.99}'
+dw workflow:history order-123 01HXYZ --follow
 
-durable-workflow schedule:create --workflow-type=reports.daily --cron="0 9 * * *"
-durable-workflow namespace:list
-durable-workflow task-queue:describe default
+dw schedule:create --workflow-type=reports.daily --cron="0 9 * * *"
+dw namespace:list
+dw task-queue:describe default
 ```
 
 See the [CLI repository README](https://github.com/durable-workflow/cli#commands) for the full command reference.

--- a/src/components/CliInstall/index.js
+++ b/src/components/CliInstall/index.js
@@ -1,0 +1,161 @@
+import React, {useEffect, useState} from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import CodeBlock from '@theme/CodeBlock';
+
+const PLATFORMS = [
+  {
+    id: 'linux-x86_64',
+    label: 'Linux (x86_64)',
+    shell: 'bash',
+    command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
+    note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
+    asset: 'durable-workflow-linux-x86_64',
+  },
+  {
+    id: 'linux-aarch64',
+    label: 'Linux (arm64)',
+    shell: 'bash',
+    command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
+    note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
+    asset: 'durable-workflow-linux-aarch64',
+  },
+  {
+    id: 'macos-aarch64',
+    label: 'macOS (Apple Silicon)',
+    shell: 'bash',
+    command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
+    note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
+    asset: 'durable-workflow-macos-aarch64',
+  },
+  {
+    id: 'windows-x86_64',
+    label: 'Windows (x86_64)',
+    shell: 'powershell',
+    command: 'irm https://durable-workflow.com/install.ps1 | iex',
+    note: 'Installs to %USERPROFILE%\\.durable-workflow\\bin and adds it to your user PATH.',
+    asset: 'durable-workflow-windows-x86_64.exe',
+  },
+];
+
+function detectPlatform() {
+  if (typeof navigator === 'undefined') return 'linux-x86_64';
+  const ua = (navigator.userAgent || '').toLowerCase();
+  const platform = (navigator.platform || '').toLowerCase();
+
+  const isArm =
+    /arm|aarch64/.test(ua) ||
+    /arm|aarch64/.test(platform) ||
+    (navigator.userAgentData && navigator.userAgentData.platform === 'macOS' && /arm/i.test(platform));
+
+  if (/win/.test(platform) || /windows/.test(ua)) return 'windows-x86_64';
+  if (/mac/.test(platform) || /mac os x/.test(ua)) return 'macos-aarch64';
+  if (/linux/.test(platform) || /linux/.test(ua)) {
+    return isArm ? 'linux-aarch64' : 'linux-x86_64';
+  }
+  return 'linux-x86_64';
+}
+
+function Installer() {
+  const [selected, setSelected] = useState(PLATFORMS[0].id);
+  const [detected, setDetected] = useState(null);
+
+  useEffect(() => {
+    const p = detectPlatform();
+    setSelected(p);
+    setDetected(p);
+  }, []);
+
+  const platform = PLATFORMS.find((p) => p.id === selected) || PLATFORMS[0];
+  const assetUrl = `https://github.com/durable-workflow/cli/releases/latest/download/${platform.asset}`;
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.5rem',
+          marginBottom: '1rem',
+        }}
+      >
+        {PLATFORMS.map((p) => {
+          const isActive = p.id === selected;
+          const isDetected = p.id === detected;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => setSelected(p.id)}
+              style={{
+                padding: '0.4rem 0.85rem',
+                borderRadius: '6px',
+                border: isActive
+                  ? '1px solid var(--ifm-color-primary)'
+                  : '1px solid var(--ifm-color-emphasis-300)',
+                background: isActive
+                  ? 'var(--ifm-color-primary)'
+                  : 'var(--ifm-background-surface-color)',
+                color: isActive ? 'white' : 'var(--ifm-color-emphasis-900)',
+                cursor: 'pointer',
+                fontSize: '0.9rem',
+              }}
+            >
+              {p.label}
+              {isDetected && !isActive ? ' •' : ''}
+            </button>
+          );
+        })}
+      </div>
+
+      {detected && detected !== selected && (
+        <p style={{fontSize: '0.85rem', color: 'var(--ifm-color-emphasis-700)'}}>
+          Detected <strong>{PLATFORMS.find((p) => p.id === detected).label}</strong>.{' '}
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              setSelected(detected);
+            }}
+          >
+            Switch back
+          </a>
+          .
+        </p>
+      )}
+
+      <CodeBlock language={platform.shell}>{platform.command}</CodeBlock>
+
+      <p style={{fontSize: '0.9rem', color: 'var(--ifm-color-emphasis-700)'}}>
+        {platform.note}
+      </p>
+
+      <details>
+        <summary>Or download the binary directly</summary>
+        <p>
+          <a href={assetUrl}>
+            <code>{platform.asset}</code>
+          </a>{' '}
+          from the{' '}
+          <a href="https://github.com/durable-workflow/cli/releases/latest">
+            latest release
+          </a>
+          .
+        </p>
+      </details>
+    </div>
+  );
+}
+
+export default function CliInstall() {
+  return (
+    <BrowserOnly
+      fallback={
+        <CodeBlock language="bash">
+          curl -fsSL https://durable-workflow.com/install.sh | sh
+        </CodeBlock>
+      }
+    >
+      {() => <Installer />}
+    </BrowserOnly>
+  );
+}

--- a/src/components/CliInstall/index.js
+++ b/src/components/CliInstall/index.js
@@ -9,7 +9,7 @@ const PLATFORMS = [
     shell: 'bash',
     command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
     note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
-    asset: 'durable-workflow-linux-x86_64',
+    asset: 'dw-linux-x86_64',
   },
   {
     id: 'linux-aarch64',
@@ -17,7 +17,7 @@ const PLATFORMS = [
     shell: 'bash',
     command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
     note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
-    asset: 'durable-workflow-linux-aarch64',
+    asset: 'dw-linux-aarch64',
   },
   {
     id: 'macos-aarch64',
@@ -25,7 +25,7 @@ const PLATFORMS = [
     shell: 'bash',
     command: 'curl -fsSL https://durable-workflow.com/install.sh | sh',
     note: 'Installs to ~/.local/bin. Set DURABLE_WORKFLOW_INSTALL_DIR to override.',
-    asset: 'durable-workflow-macos-aarch64',
+    asset: 'dw-macos-aarch64',
   },
   {
     id: 'windows-x86_64',
@@ -33,7 +33,7 @@ const PLATFORMS = [
     shell: 'powershell',
     command: 'irm https://durable-workflow.com/install.ps1 | iex',
     note: 'Installs to %USERPROFILE%\\.durable-workflow\\bin and adds it to your user PATH.',
-    asset: 'durable-workflow-windows-x86_64.exe',
+    asset: 'dw-windows-x86_64.exe',
   },
 ];
 

--- a/static/install.ps1
+++ b/static/install.ps1
@@ -10,7 +10,7 @@
 $ErrorActionPreference = 'Stop'
 
 $repo = 'durable-workflow/cli'
-$binName = 'durable-workflow.exe'
+$binName = 'dw.exe'
 $installDir = if ($env:DURABLE_WORKFLOW_INSTALL_DIR) {
     $env:DURABLE_WORKFLOW_INSTALL_DIR
 } else {
@@ -23,7 +23,7 @@ if (-not [System.Environment]::Is64BitOperatingSystem) {
 }
 
 $arch = 'x86_64'
-$asset = "durable-workflow-windows-$arch.exe"
+$asset = "dw-windows-$arch.exe"
 
 $url = if ($version -eq 'latest') {
     "https://github.com/$repo/releases/latest/download/$asset"

--- a/static/install.ps1
+++ b/static/install.ps1
@@ -1,0 +1,53 @@
+# Durable Workflow CLI installer for Windows.
+#
+# Usage:
+#   irm https://durable-workflow.com/install.ps1 | iex
+#
+# Env vars:
+#   $env:VERSION                       Pin a release tag (default: latest).
+#   $env:DURABLE_WORKFLOW_INSTALL_DIR  Install directory (default: %USERPROFILE%\.durable-workflow\bin).
+
+$ErrorActionPreference = 'Stop'
+
+$repo = 'durable-workflow/cli'
+$binName = 'durable-workflow.exe'
+$installDir = if ($env:DURABLE_WORKFLOW_INSTALL_DIR) {
+    $env:DURABLE_WORKFLOW_INSTALL_DIR
+} else {
+    Join-Path $env:USERPROFILE '.durable-workflow\bin'
+}
+$version = if ($env:VERSION) { $env:VERSION } else { 'latest' }
+
+if (-not [System.Environment]::Is64BitOperatingSystem) {
+    throw 'Durable Workflow CLI requires a 64-bit operating system.'
+}
+
+$arch = 'x86_64'
+$asset = "durable-workflow-windows-$arch.exe"
+
+$url = if ($version -eq 'latest') {
+    "https://github.com/$repo/releases/latest/download/$asset"
+} else {
+    "https://github.com/$repo/releases/download/$version/$asset"
+}
+
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$dest = Join-Path $installDir $binName
+
+Write-Host "==> Downloading $asset" -ForegroundColor Green
+try {
+    Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+} catch {
+    throw "Download failed: $url`n$_"
+}
+
+Write-Host "==> Installed $binName to $installDir" -ForegroundColor Green
+
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$paths = @($userPath -split ';' | Where-Object { $_ })
+if ($paths -notcontains $installDir) {
+    [Environment]::SetEnvironmentVariable('Path', (($paths + $installDir) -join ';'), 'User')
+    Write-Host "==> Added $installDir to your user PATH. Restart your shell for the change to take effect." -ForegroundColor Green
+}
+
+& $dest --version

--- a/static/install.sh
+++ b/static/install.sh
@@ -7,12 +7,12 @@
 # Env vars:
 #   VERSION                  Pin a specific release tag (default: latest).
 #   DURABLE_WORKFLOW_INSTALL_DIR  Where to place the binary (default: ~/.local/bin).
-#   DURABLE_WORKFLOW_BIN_NAME     Executable name (default: durable-workflow).
+#   DURABLE_WORKFLOW_BIN_NAME     Executable name (default: dw).
 
 set -eu
 
 REPO="durable-workflow/cli"
-BIN_NAME="${DURABLE_WORKFLOW_BIN_NAME:-durable-workflow}"
+BIN_NAME="${DURABLE_WORKFLOW_BIN_NAME:-dw}"
 INSTALL_DIR="${DURABLE_WORKFLOW_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${VERSION:-latest}"
 
@@ -37,10 +37,10 @@ esac
 
 # No macos-x86_64 binary is currently published.
 if [ "$os" = "macos" ] && [ "$arch" = "x86_64" ]; then
-    err "macos-x86_64 binaries are not currently published. Use the PHAR, or install via Homebrew once the tap is available."
+    err "macos-x86_64 binaries are not currently published. Use the PHAR with a system PHP instead."
 fi
 
-asset="durable-workflow-${os}-${arch}"
+asset="dw-${os}-${arch}"
 
 if [ "$VERSION" = "latest" ]; then
     url="https://github.com/${REPO}/releases/latest/download/${asset}"

--- a/static/install.sh
+++ b/static/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# Durable Workflow CLI installer for Linux and macOS.
+#
+# Usage:
+#   curl -fsSL https://durable-workflow.com/install.sh | sh
+#
+# Env vars:
+#   VERSION                  Pin a specific release tag (default: latest).
+#   DURABLE_WORKFLOW_INSTALL_DIR  Where to place the binary (default: ~/.local/bin).
+#   DURABLE_WORKFLOW_BIN_NAME     Executable name (default: durable-workflow).
+
+set -eu
+
+REPO="durable-workflow/cli"
+BIN_NAME="${DURABLE_WORKFLOW_BIN_NAME:-durable-workflow}"
+INSTALL_DIR="${DURABLE_WORKFLOW_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${VERSION:-latest}"
+
+err() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[32m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
+
+uname_s=$(uname -s)
+uname_m=$(uname -m)
+
+case "$uname_s" in
+    Linux)  os="linux" ;;
+    Darwin) os="macos" ;;
+    *) err "unsupported OS: $uname_s (Windows users: use install.ps1)" ;;
+esac
+
+case "$uname_m" in
+    x86_64|amd64)  arch="x86_64" ;;
+    arm64|aarch64) arch="aarch64" ;;
+    *) err "unsupported architecture: $uname_m" ;;
+esac
+
+# No macos-x86_64 binary is currently published.
+if [ "$os" = "macos" ] && [ "$arch" = "x86_64" ]; then
+    err "macos-x86_64 binaries are not currently published. Use the PHAR, or install via Homebrew once the tap is available."
+fi
+
+asset="durable-workflow-${os}-${arch}"
+
+if [ "$VERSION" = "latest" ]; then
+    url="https://github.com/${REPO}/releases/latest/download/${asset}"
+else
+    url="https://github.com/${REPO}/releases/download/${VERSION}/${asset}"
+fi
+
+command -v curl >/dev/null 2>&1 || err "curl is required"
+
+mkdir -p "$INSTALL_DIR"
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+info "Downloading $asset"
+if ! curl -fsSL --retry 3 -o "$tmp" "$url"; then
+    err "download failed: $url"
+fi
+
+[ -s "$tmp" ] || err "downloaded file is empty"
+
+chmod +x "$tmp"
+mv "$tmp" "$INSTALL_DIR/$BIN_NAME"
+trap - EXIT
+
+info "Installed $BIN_NAME to $INSTALL_DIR"
+
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        warn "$INSTALL_DIR is not in your PATH. Add this to your shell profile:"
+        printf '    export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+        ;;
+esac
+
+"$INSTALL_DIR/$BIN_NAME" --version || true


### PR DESCRIPTION
## Summary
- Hosts `install.sh` (Linux/macOS) and `install.ps1` (Windows) at the site root so users can run `curl -fsSL https://durable-workflow.com/install.sh | sh` or `irm https://durable-workflow.com/install.ps1 | iex`.
- Adds a v2 docs page at `/docs/2.0/cli/` with an OS-detecting platform switcher — auto-selects the visitor's OS/arch but lets them switch.
- Both scripts pull the matching asset from the latest [`durable-workflow/cli`](https://github.com/durable-workflow/cli/releases) release. `VERSION=v1.2.3` and `DURABLE_WORKFLOW_INSTALL_DIR` env vars let users pin a version or change the install location.
- No changes to 1.x frozen docs.

## Test plan
- [x] `npm run build` succeeds
- [ ] After merge+deploy: `curl -fsSL https://durable-workflow.com/install.sh | sh` installs a working binary on Linux
- [ ] After merge+deploy: `irm https://durable-workflow.com/install.ps1 | iex` installs a working .exe on Windows
- [ ] Page at `/docs/2.0/cli/` auto-selects the correct platform

Note: install scripts depend on the first tagged release of `durable-workflow/cli` being published so the `releases/latest/download/...` URLs resolve.